### PR TITLE
bump ack lab sdk to simplify receipt validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ack-lab/sdk": "0.0.5",
+        "@ack-lab/sdk": "0.0.7",
         "@ai-sdk/anthropic": "^2.0.4",
         "@hono/node-server": "^1.18.2",
         "@hono/valibot-validator": "^0.5.3",
@@ -17,7 +17,7 @@
         "agentcommercekit": "^0.10.0",
         "ai": "^5.0.14",
         "dotenv": "^17.2.1",
-        "hono": "^4.9.1",
+        "hono": "^4.9.6",
         "valibot": "^1.1.0",
         "yoctocolors": "^2.1.1",
         "zod": "^3.0.25"
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@ack-lab/sdk": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@ack-lab/sdk/-/sdk-0.0.5.tgz",
-      "integrity": "sha512-AKC4cvqoUsx2i2yJFAn2BJXfKkp+nE7Ag1mNL4w62M+E3enuApC6aEaPg47UEOxkE+7CGzZmH+AAzYpX12w+Lg==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@ack-lab/sdk/-/sdk-0.0.7.tgz",
+      "integrity": "sha512-9cNVj9gY1+qV+8msJu6gGYHCvGqrsGXDWRoh5bND2CC6vI8v9tXRjQ7remNaoK608AOBKhk+J3bsqogCi7W6FQ==",
       "license": "MIT",
       "dependencies": {
         "agentcommercekit": "^0.10.0",
@@ -2603,9 +2603,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.4.tgz",
-      "integrity": "sha512-61hl6MF6ojTl/8QSRu5ran6GXt+6zsngIUN95KzF5v5UjiX/xnrLR358BNRawwIRO49JwUqJqQe3Rb2v559R8Q==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.6.tgz",
+      "integrity": "sha512-doVjXhSFvYZ7y0dNokjwwSahcrAfdz+/BCLvAMa/vHLzjj8+CFyV5xteThGUsKdkaasgN+gF2mUxao+SGLpUeA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ack-lab/sdk": "0.0.5",
+    "@ack-lab/sdk": "0.0.7",
     "@ai-sdk/anthropic": "^2.0.4",
     "@hono/node-server": "^1.18.2",
     "@hono/valibot-validator": "^0.5.3",
@@ -27,7 +27,7 @@
     "agentcommercekit": "^0.10.0",
     "ai": "^5.0.14",
     "dotenv": "^17.2.1",
-    "hono": "^4.9.1",
+    "hono": "^4.9.6",
     "valibot": "^1.1.0",
     "yoctocolors": "^2.1.1",
     "zod": "^3.0.25"


### PR DESCRIPTION
Pulls in sdk changes [here](https://github.com/catena-labs/ack-lab-sdk) to provide a utility for parsing receipt JWTs. Use this to extract the original payment request ID, and key on payment request ID to track transactions instead of the full payment token.